### PR TITLE
Corrected CSS reference for websites in subfolder

### DIFF
--- a/tmpl/default.php
+++ b/tmpl/default.php
@@ -21,7 +21,7 @@ if ($bs3dropdwn == 1)
 	{
 		$document->addScript(JURI::base(true).'/modules/mod_bootstrap3_menu/assets/bootstrap.dropdown.hover.display.min.js');
 	}
-	if ($bs3css == 1) $document->addStyleSheet('/modules/mod_bootstrap3_menu/assets/bootstrap3_menu.css');
+	if ($bs3css == 1) $document->addStyleSheet(JURI::base(true).'/modules/mod_bootstrap3_menu/assets/bootstrap3_menu.css');
 }
 
 // Note. It is important to remove spaces between elements.


### PR DESCRIPTION
The references to a CSS file is not correct if your website is not directly under the root.

If your website is located at
http://localhost/
then 
	if ($bs3css == 1) $document->addStyleSheet('/modules/mod_bootstrap3_menu/assets/bootstrap3_menu.css');
retrieves the asset correctly from
http://localhost/modules/mod_bootstrap3_menu/assets/bootstrap3_menu.css

However, this does not work correctly if your website is located in subfolder like http://localhost/my_website_in_subfolder/ 
This small patch fixes that..